### PR TITLE
Fix broken html2canvas link

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
     </div>
     
     <script src="lib/us-map-svg.js"></script>
-    <script src="lib/html2canvas.min.js"></script>
     <script src="lib/raphael-min.js"></script>
     <script src="script.js"></script>
 


### PR DESCRIPTION
## Summary
- remove reference to `html2canvas.min.js` which isn't included in the repo

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a4edcaa648326b5b4c051b40c42cb